### PR TITLE
Remove use of deprecated element

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name" : "JSON Formatter",
   "description" : "A Chrome app for formatting JSON.",
-  "version" : "0.1.6",
+  "version" : "0.1.7",
   "manifest_version" : 2,
   "offline_enabled": true,
   "app" : {

--- a/app/view/css/style.css
+++ b/app/view/css/style.css
@@ -1,3 +1,6 @@
+#main-body {
+	text-align: center;
+}
 body {
     background-color: #101010;
 }

--- a/app/view/window.html
+++ b/app/view/window.html
@@ -8,15 +8,13 @@
 </head>
 
 <body>
-    <center>
-        <span id="notification-area"></span>
-        <br>
-        <textarea id="json-input" rows="10" cols="40" spellcheck="false" placeholder="Paste your JSON here."></textarea>
-        <br>
-        <br>
-        <button type="button" id="formatButton" class="btn">Format JSON</button>
-        <button class="btn" type="button" id="selectAllButton">Copy</button>
-    </center>
+    <span id="notification-area"></span>
+    <br>
+    <textarea id="json-input" rows="10" cols="40" spellcheck="false" placeholder="Paste your JSON here."></textarea>
+    <br>
+    <br>
+    <button type="button" id="formatButton" class="btn">Format JSON</button>
+    <button class="btn" type="button" id="selectAllButton">Copy</button>
     <script src="js/jquery.min.js"></script>
     <script src="js/formatter.js"></script>
 </body>

--- a/app/view/window.html
+++ b/app/view/window.html
@@ -8,15 +8,17 @@
 </head>
 
 <body>
-    <span id="notification-area"></span>
-    <br>
-    <textarea id="json-input" rows="10" cols="40" spellcheck="false" placeholder="Paste your JSON here."></textarea>
-    <br>
-    <br>
-    <button type="button" id="formatButton" class="btn">Format JSON</button>
-    <button class="btn" type="button" id="selectAllButton">Copy</button>
-    <script src="js/jquery.min.js"></script>
-    <script src="js/formatter.js"></script>
+    <div id="main-body">
+        <span id="notification-area"></span>
+        <br>
+        <textarea id="json-input" rows="10" cols="40" spellcheck="false" placeholder="Paste your JSON here."></textarea>
+        <br>
+        <br>
+        <button type="button" id="formatButton" class="btn">Format JSON</button>
+        <button class="btn" type="button" id="selectAllButton">Copy</button>
+        <script src="js/jquery.min.js"></script>
+        <script src="js/formatter.js"></script>
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
Removed use of deprecated `<center>` element.

Page content is now in a `<div>` with `text-align` set to `center`.
